### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/display-as/tests/loop_in_let.rs
+++ b/display-as/tests/loop_in_let.rs
@@ -21,7 +21,7 @@ fn test_loop_no_let() {
     assert_eq!(
         format_as!(
             HTML,
-            for i in [1u8, 2].into_iter() {
+            for i in [1u8, 2].iter() {
                 "counting " * i
             }
         ),
@@ -33,7 +33,7 @@ fn test_loop_no_let() {
 fn test_loop_no_let_b() {
     assert_eq!(
         format_as!(HTML,
-        for i in [1u8,2].into_iter() {
+        for i in [1u8,2].iter() {
             let j: u8 = *i;
             "counting " j
         }),


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
