### PR TITLE
Update gotham to 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.33.0
+  - 1.36.0
   - stable
   - beta
   - nightly

--- a/display-as/Cargo.toml
+++ b/display-as/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "droundy/display-as", branch = "master" }
 
 [features]
 
-gotham-web = ["gotham", "hyper", "http"]
+gotham-web = ["gotham"]
 docinclude = []
 usewarp = ["warp", "http", "hyper"]
 
@@ -31,7 +31,7 @@ percent-encoding = "1.0.1"
 
 rouille = { version = "2.2.0", optional = true }
 actix-web = { version = "0.7.14", optional = true }
-gotham = { version = "0.3.0", optional = true }
+gotham = { version = "0.5.0", optional = true }
 hyper = { version = "0.13", optional = true }
 http = { version = "0.2.1", optional = true }
 warp = { version = "0.2.4", optional = true }

--- a/display-as/src/lib.rs
+++ b/display-as/src/lib.rs
@@ -373,14 +373,16 @@ pub mod actix {
 }
 
 /// The `gotham-web` feature flag makes any [As] type a
-/// [gotham::IntoResponse].
-#[cfg(feature = "gotham-web")]
+/// [::gotham::handler::IntoResponse].
+#[cfg(feature = "gotham")]
 pub mod gotham {
     use crate::{As, DisplayAs, Format};
-    impl<'a, F: Format, T: 'a + DisplayAs<F>> gotham::handler::IntoResponse for As<'a, F, T> {
-        fn into_response(self, state: &gotham::state::State) -> http::Response<hyper::Body> {
+	use gotham::{hyper::{Body, Response, StatusCode}, handler::IntoResponse, state::State};
+	
+    impl<'a, F: Format, T: 'a + DisplayAs<F>> IntoResponse for As<'a, F, T> {
+        fn into_response(self, state: &State) -> Response<Body> {
             let s = format!("{}", self);
-            (http::StatusCode::OK, F::mime(), s).into_response(state)
+            (StatusCode::OK, F::mime(), s).into_response(state)
         }
     }
 }


### PR DESCRIPTION
This PR updates gotham from 0.3.0 to 0.5.0, which should also fix the [compile issue on docs.rs](https://docs.rs/crate/display-as/0.5.1/builds/308664).