### PR TITLE
Fix building on docs.rs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all --features display-as/gotham-web,display-as/usewarp,display-as/serde
+          # Older rustc versions don't support passing --features with --all
+          args: --all --features ${{ matrix.rust == "stable" && gotham-web,usewarp,serde || "" }}
 
   test:
     name: Test Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           command: check
           # Older rustc versions don't support passing --features with --all
-          args: --all --features ${{ matrix.rust == 'stable' && 'gotham-web,usewarp,serde' || '' }}
+          args: --all ${{ matrix.rust == 'stable' && '--features gotham-web,usewarp,serde' || '' }}
 
   test:
     name: Test Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all
+          args: --all --features gotham-web,usewarp,serde1
 
   test:
     name: Test Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all --features gotham-web,usewarp,serde1
+          args: --all --features display-as/gotham-web,display-as/usewarp,display-as/serde
 
   test:
     name: Test Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           command: check
           # Older rustc versions don't support passing --features with --all
-          args: --all --features ${{ matrix.rust == "stable" && gotham-web,usewarp,serde || "" }}
+          args: --all --features ${{ matrix.rust == 'stable' && gotham-web,usewarp,serde || '' }}
 
   test:
     name: Test Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.45.0
+          - 1.54.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -21,8 +21,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          # Older rustc versions don't support passing --features with --all
-          args: --all ${{ matrix.rust == 'stable' && '--features gotham-web,usewarp,serde' || '' }}
+          args: --all --all-features
 
   test:
     name: Test Suite
@@ -31,7 +30,7 @@ jobs:
       matrix:
         rust:
           - stable
-          # - 1.45.0
+          # - 1.54.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           command: check
           # Older rustc versions don't support passing --features with --all
-          args: --all --features ${{ matrix.rust == 'stable' && gotham-web,usewarp,serde || '' }}
+          args: --all --features ${{ matrix.rust == 'stable' && 'gotham-web,usewarp,serde' || '' }}
 
   test:
     name: Test Suite

--- a/display-as/Cargo.toml
+++ b/display-as/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 [features]
 
 gotham-web = ["gotham"]
-docinclude = []
 usewarp = ["warp", "http", "hyper"]
 serde1 = ["serde"]
 

--- a/display-as/Cargo.toml
+++ b/display-as/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 gotham-web = ["gotham"]
 docinclude = []
 usewarp = ["warp", "http", "hyper"]
-serde1 = ["serde", "serde_derive"]
+serde1 = ["serde"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -33,8 +33,7 @@ hyper = { version = "0.13", optional = true }
 http = { version = "0.2.1", optional = true }
 warp = { version = "0.2.4", optional = true }
 
-serde = { version = "1.0.125", optional = true }
-serde_derive = { version = "1.0.125", optional = true }
+serde = { version = "1.0.125", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.2"

--- a/display-as/src/lib.rs
+++ b/display-as/src/lib.rs
@@ -486,7 +486,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde1", serde(bound(deserialize = "F: Format")))]
 pub struct FormattedString<F> {
     inner: String,
-    #[serde(skip, default = "F::this_format")]
+    #[cfg_attr(feature = "serde1", serde(skip, default = "F::this_format"))]
     _format: F,
 }
 

--- a/display-as/src/lib.rs
+++ b/display-as/src/lib.rs
@@ -160,7 +160,6 @@
 //! editors will hopefully be able to do the "right thing" for the
 //! template format (e.g. HTML in this case).
 
-#![cfg_attr(feature = "docinclude", feature(external_doc))]
 //! ## Using `include!("...")` within a template
 //!
 //! Now I will demonstrate how you can include template files within
@@ -171,17 +170,17 @@
 //! laid out.
 //! #### `base.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc(include = "base.html"))]
+#![cfg_attr(feature = "docinclude", doc = include_str!("base.html"))]
 //! ```
 //! We can have a template for how we will display students...
 //! #### `student.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc(include = "student.html"))]
+#![cfg_attr(feature = "docinclude", doc = include_str!("student.html"))]
 //!```
 //! Finally, an actual web page describing a class!
 //! #### `class.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc(include = "class.html"))]
+#![cfg_attr(feature = "docinclude", doc = include_str!("class.html"))]
 //! ```
 //! Now to put all this together, we'll need some rust code.
 //!
@@ -475,7 +474,7 @@ mod tests {
 }
 
 #[cfg(feature = "serde1")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// A `String` that is formatted in `F`
 ///
@@ -484,8 +483,10 @@ use serde::{Serialize, Deserialize};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde1", serde(transparent))]
+#[cfg_attr(feature = "serde1", serde(bound(deserialize = "F: Format")))]
 pub struct FormattedString<F> {
     inner: String,
+    #[serde(skip, default = "F::this_format")]
     _format: F,
 }
 

--- a/display-as/src/lib.rs
+++ b/display-as/src/lib.rs
@@ -170,17 +170,17 @@
 //! laid out.
 //! #### `base.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc = include_str!("base.html"))]
+#![doc = include_str!("base.html")]
 //! ```
 //! We can have a template for how we will display students...
 //! #### `student.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc = include_str!("student.html"))]
+#![doc = include_str!("student.html")]
 //!```
 //! Finally, an actual web page describing a class!
 //! #### `class.html`:
 //! ```ignore
-#![cfg_attr(feature = "docinclude", doc = include_str!("class.html"))]
+#![doc = include_str!("class.html")]
 //! ```
 //! Now to put all this together, we'll need some rust code.
 //!


### PR DESCRIPTION
docs.rs has failed to build the latest version of this library due to the serde1 feature flag being broken, this PR fixes that. I changed the semantics of serde to get it to compile, I hope it's what you want.

Also makes sure that the features that were causing it to fail are now checked on CI.